### PR TITLE
v1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,3 @@ dist/
 
 # Visual Studio Code
 .vscode/
-
-# Documents - in work
-docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.5.0 (December 5, 2020)
+
+* Added `excludePaths` and `includeOnlyPaths` options for `whenFileContent` condition.
+* Added `between` option for `whenFileCount`, `whenCommentCount`, and `whenCommitCount` conditions.
+* Added `whenHasRequestsToReview` and `whenHasNoRequestsToReview` conditions.
+* Fixed bugs with missed options in `whenHasConflicts`, `whenHasNoConflicts`,
+  `whenOpen`, `whenClosed`, and `whenWasMerged` conditions.
+
 ## v1.4.0 (November 21, 2020)
 
 * Added async support for `WhenCondition`.
@@ -16,7 +24,6 @@
 
 * Added actions `requestReviewers` and `removeRequestedReviewers`.
 * Added conditions `whenNotReviewed`, `whenApproved`, and `whenChangesRequested`.
-* Improved unit tests.
 * Updated dependencies.
 
 ## v1.1.0 (November 5, 2020)

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ const config = createConfig();
 
 config
   .addLabel('back end')
-  .whenFilePath(/\.cs$/gi);
+  .whenFilePath(/\.cs$/);
 
 config
   .addLabel('front end')
-  .whenFilePath(/\.(((t|j)sx?)|(s?css))$/gi);
+  .whenFilePath(/\.(((t|j)sx?)|(s?css))$/);
 
 // repository options
 const repository = {

--- a/example/config.ts
+++ b/example/config.ts
@@ -5,15 +5,15 @@ export function makeConfig(): IConfig {
 
   config
     .addLabel('back end')
-    .whenFilePath(/\.cs$/gi);
+    .whenFilePath(/\.cs$/);
 
   config
     .addLabel('front end')
-    .whenFilePath(/\.(((t|j)sx?)|(s?css))$/gi);
+    .whenFilePath(/\.(((t|j)sx?)|(s?css))$/);
 
   config
     .addLabel('database')
-    .whenFilePath(/\.sql$/gi);
+    .whenFilePath(/\.sql$/);
 
   return config;
 }

--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,6 @@
     "typescript": "4.0.5"
   },
   "dependencies": {
-    "bighut-relabel": "^1.4.0"
+    "bighut-relabel": "^1.5.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bighut-relabel",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bighut-relabel",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Automatically analyze and manage pull requests on GitHub.",
   "main": "dist/index.js",
   "files": [

--- a/src/Actions/BaseAction.ts
+++ b/src/Actions/BaseAction.ts
@@ -16,7 +16,7 @@ import {
   WhenCommitMessageCondition,
   WhenCondition,
   WhenConditionPredicate,
-  WhenContainsConflicts,
+  WhenContainsConflictsCondition,
   WhenContainsRequestsToReviewCondition,
   WhenDescriptionCondition,
   WhenFileContentCondition,
@@ -199,7 +199,7 @@ export abstract class BaseAction implements IAction {
 
   public whenHasConflicts(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsConflicts(true);
+    const condition = new WhenContainsConflictsCondition(true);
 
     this.addCondition(condition);
 
@@ -208,7 +208,7 @@ export abstract class BaseAction implements IAction {
 
   public whenHasNoConflicts(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsConflicts(false);
+    const condition = new WhenContainsConflictsCondition(false);
 
     this.addCondition(condition);
 

--- a/src/Actions/BaseAction.ts
+++ b/src/Actions/BaseAction.ts
@@ -1,6 +1,7 @@
 import {
   DefaultConditionOptions,
   WhenCommentTextConditionOptions,
+  WhenContainsRequestsToReviewConditionOptions,
   WhenFileContentConditionOptions,
   WhenFilePathConditionOptions,
   WhenInternalConditionOptions,
@@ -215,18 +216,18 @@ export abstract class BaseAction implements IAction {
     return options;
   }
 
-  public whenHasRequestsToReview(): DefaultConditionOptions {
-    const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsRequestsToReviewCondition(true);
+  public whenHasRequestsToReview(): WhenContainsRequestsToReviewConditionOptions {
+    const options = new WhenContainsRequestsToReviewConditionOptions(this);
+    const condition = new WhenContainsRequestsToReviewCondition(true, options);
 
     this.addCondition(condition);
 
     return options;
   }
 
-  public whenHasNoRequestsToReview(): DefaultConditionOptions {
-    const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsRequestsToReviewCondition(false);
+  public whenHasNoRequestsToReview(): WhenContainsRequestsToReviewConditionOptions {
+    const options = new WhenContainsRequestsToReviewConditionOptions(this);
+    const condition = new WhenContainsRequestsToReviewCondition(false, options);
 
     this.addCondition(condition);
 

--- a/src/Actions/BaseAction.ts
+++ b/src/Actions/BaseAction.ts
@@ -17,7 +17,7 @@ import {
   WhenCondition,
   WhenConditionPredicate,
   WhenContainsConflicts,
-  WhenContainsRequestsToReview,
+  WhenContainsRequestsToReviewCondition,
   WhenDescriptionCondition,
   WhenFileContentCondition,
   WhenFileCountCondition,
@@ -217,7 +217,7 @@ export abstract class BaseAction implements IAction {
 
   public whenHasRequestsToReview(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsRequestsToReview(true);
+    const condition = new WhenContainsRequestsToReviewCondition(true);
 
     this.addCondition(condition);
 
@@ -226,7 +226,7 @@ export abstract class BaseAction implements IAction {
 
   public whenHasNoRequestsToReview(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsRequestsToReview(false);
+    const condition = new WhenContainsRequestsToReviewCondition(false);
 
     this.addCondition(condition);
 

--- a/src/Actions/BaseAction.ts
+++ b/src/Actions/BaseAction.ts
@@ -17,6 +17,7 @@ import {
   WhenCondition,
   WhenConditionPredicate,
   WhenContainsConflicts,
+  WhenContainsRequestsToReview,
   WhenDescriptionCondition,
   WhenFileContentCondition,
   WhenFileCountCondition,
@@ -208,6 +209,24 @@ export abstract class BaseAction implements IAction {
   public whenHasNoConflicts(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
     const condition = new WhenContainsConflicts(false);
+
+    this.addCondition(condition);
+
+    return options;
+  }
+
+  public whenHasRequestsToReview(): DefaultConditionOptions {
+    const options = new DefaultConditionOptions(this);
+    const condition = new WhenContainsRequestsToReview(true);
+
+    this.addCondition(condition);
+
+    return options;
+  }
+
+  public whenHasNoRequestsToReview(): DefaultConditionOptions {
+    const options = new DefaultConditionOptions(this);
+    const condition = new WhenContainsRequestsToReview(false);
 
     this.addCondition(condition);
 

--- a/src/Actions/BaseAction.ts
+++ b/src/Actions/BaseAction.ts
@@ -200,7 +200,7 @@ export abstract class BaseAction implements IAction {
 
   public whenHasConflicts(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsConflictsCondition(true);
+    const condition = new WhenContainsConflictsCondition(true, options);
 
     this.addCondition(condition);
 
@@ -209,7 +209,7 @@ export abstract class BaseAction implements IAction {
 
   public whenHasNoConflicts(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenContainsConflictsCondition(false);
+    const condition = new WhenContainsConflictsCondition(false, options);
 
     this.addCondition(condition);
 
@@ -272,7 +272,7 @@ export abstract class BaseAction implements IAction {
 
   public whenOpen(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenStateCondition('open');
+    const condition = new WhenStateCondition('open', options);
 
     this.addCondition(condition);
 
@@ -281,7 +281,7 @@ export abstract class BaseAction implements IAction {
 
   public whenClosed(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenStateCondition('closed');
+    const condition = new WhenStateCondition('closed', options);
 
     this.addCondition(condition);
 
@@ -290,7 +290,7 @@ export abstract class BaseAction implements IAction {
 
   public whenWasMerged(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenStateCondition('merged');
+    const condition = new WhenStateCondition('merged', options);
 
     this.addCondition(condition);
 

--- a/src/Actions/BaseAction.ts
+++ b/src/Actions/BaseAction.ts
@@ -28,7 +28,7 @@ import {
   WhenMilestoneNameCondition,
   WhenReviewStateCondition,
   WhenSourceBranchNameCondition,
-  WhenState,
+  WhenStateCondition,
   WhenTargetBranchNameCondition,
   WhenTitleCondition,
 } from '../Conditions';
@@ -271,7 +271,7 @@ export abstract class BaseAction implements IAction {
 
   public whenOpen(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenState('open');
+    const condition = new WhenStateCondition('open');
 
     this.addCondition(condition);
 
@@ -280,7 +280,7 @@ export abstract class BaseAction implements IAction {
 
   public whenClosed(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenState('closed');
+    const condition = new WhenStateCondition('closed');
 
     this.addCondition(condition);
 
@@ -289,7 +289,7 @@ export abstract class BaseAction implements IAction {
 
   public whenWasMerged(): DefaultConditionOptions {
     const options = new DefaultConditionOptions(this);
-    const condition = new WhenState('merged');
+    const condition = new WhenStateCondition('merged');
 
     this.addCondition(condition);
 

--- a/src/Actions/RemoveRequestedReviewersAction.ts
+++ b/src/Actions/RemoveRequestedReviewersAction.ts
@@ -9,7 +9,7 @@ export class RemoveRequestedReviewersAction extends BaseAction {
   public readonly getUsernames: { (context: LabelerContext): Array<string> };
 
   constructor(
-    usernames: Array<string> | { (context?: LabelerContext): Array<string> },
+    usernames: string | Array<string> | { (context?: LabelerContext): Array<string> },
     config: IConfig
   ) {
     super(config);
@@ -17,7 +17,7 @@ export class RemoveRequestedReviewersAction extends BaseAction {
     if (typeof usernames === 'function') {
       this.getUsernames = usernames;
     } else {
-      this.usernames = usernames;
+      this.usernames = [].concat(usernames);
     }
   }
 

--- a/src/Actions/RequestReviewersAction.ts
+++ b/src/Actions/RequestReviewersAction.ts
@@ -9,7 +9,7 @@ export class RequestReviewersAction extends BaseAction {
   public readonly getUsernames: { (context: LabelerContext): Array<string> };
 
   constructor(
-    usernames: Array<string> | { (context?: LabelerContext): Array<string> },
+    usernames: string | Array<string> | { (context?: LabelerContext): Array<string> },
     config: IConfig
   ) {
     super(config);
@@ -17,7 +17,7 @@ export class RequestReviewersAction extends BaseAction {
     if (typeof usernames === 'function') {
       this.getUsernames = usernames;
     } else {
-      this.usernames = usernames;
+      this.usernames = [].concat(usernames);
     }
   }
 

--- a/src/ApiProviders/GitHubClient.ts
+++ b/src/ApiProviders/GitHubClient.ts
@@ -106,6 +106,7 @@ export class GitHubClient implements IApiProviderClient {
             code: item.milestone.number,
             name: item.milestone.title,
           },
+          requestedReviewers: item.requested_reviewers?.map(this.convertDataToUser) || [],
           createdDate: item.created_at && new Date(item.created_at),
           updatedDate: item.updated_at && new Date(item.updated_at),
           mergedDate: item.merged_at && new Date(item.merged_at),

--- a/src/ApiProviders/Types/PullRequest.ts
+++ b/src/ApiProviders/Types/PullRequest.ts
@@ -50,4 +50,6 @@ export type PullRequest = {
 
   statusInfo: CacheableAction<PullRequestStatus>;
 
+  requestedReviewers?: Array<User>;
+
 };

--- a/src/ConditionOptions/Values/NumberConditionOptionsValues.ts
+++ b/src/ConditionOptions/Values/NumberConditionOptionsValues.ts
@@ -12,4 +12,9 @@ export type NumberConditionOptionsValues = ConditionOptionsValues & {
 
   greaterThanOrEqualTo?: number;
 
+  between?: {
+    from: number;
+    to: number;
+  }
+
 };

--- a/src/ConditionOptions/Values/WhenFileContentConditionOptionsValues.ts
+++ b/src/ConditionOptions/Values/WhenFileContentConditionOptionsValues.ts
@@ -1,3 +1,4 @@
+import { StringTestValue } from '../../Types';
 import { ConditionOptionsValues } from './ConditionOptionsValues';
 
 export type WhenFileContentConditionOptionsValues = ConditionOptionsValues & {
@@ -5,5 +6,7 @@ export type WhenFileContentConditionOptionsValues = ConditionOptionsValues & {
   onlyNewFiles?: boolean;
 
   onlyModifiedFiles?: boolean;
+
+  excludePaths?: StringTestValue;
 
 };

--- a/src/ConditionOptions/Values/WhenFileContentConditionOptionsValues.ts
+++ b/src/ConditionOptions/Values/WhenFileContentConditionOptionsValues.ts
@@ -9,4 +9,6 @@ export type WhenFileContentConditionOptionsValues = ConditionOptionsValues & {
 
   excludePaths?: StringTestValue;
 
+  includeOnlyPaths?: StringTestValue;
+
 };

--- a/src/ConditionOptions/WhenContainsRequestsToReviewConditionOptions.ts
+++ b/src/ConditionOptions/WhenContainsRequestsToReviewConditionOptions.ts
@@ -1,0 +1,22 @@
+import { BaseConditionOptions } from './BaseConditionOptions';
+import { ArrayConditionOptionsValues } from './Values';
+
+export class WhenReviewStateConditionOptions extends BaseConditionOptions<ArrayConditionOptionsValues<string>> {
+
+  public oneOf(logins: Array<string>): WhenReviewStateConditionOptions {
+    this.values.oneOf = true;
+    this.values.all = false;
+    this.values.value = logins;
+
+    return this;
+  }
+
+  public all(logins: Array<string>): WhenReviewStateConditionOptions {
+    this.values.oneOf = false;
+    this.values.all = true;
+    this.values.value = logins;
+
+    return this;
+  }
+
+}

--- a/src/ConditionOptions/WhenContainsRequestsToReviewConditionOptions.ts
+++ b/src/ConditionOptions/WhenContainsRequestsToReviewConditionOptions.ts
@@ -1,9 +1,9 @@
 import { BaseConditionOptions } from './BaseConditionOptions';
 import { ArrayConditionOptionsValues } from './Values';
 
-export class WhenReviewStateConditionOptions extends BaseConditionOptions<ArrayConditionOptionsValues<string>> {
+export class WhenContainsRequestsToReviewConditionOptions extends BaseConditionOptions<ArrayConditionOptionsValues<string>> {
 
-  public oneOf(logins: Array<string>): WhenReviewStateConditionOptions {
+  public oneOf(logins: Array<string>): WhenContainsRequestsToReviewConditionOptions {
     this.values.oneOf = true;
     this.values.all = false;
     this.values.value = logins;
@@ -11,7 +11,7 @@ export class WhenReviewStateConditionOptions extends BaseConditionOptions<ArrayC
     return this;
   }
 
-  public all(logins: Array<string>): WhenReviewStateConditionOptions {
+  public all(logins: Array<string>): WhenContainsRequestsToReviewConditionOptions {
     this.values.oneOf = false;
     this.values.all = true;
     this.values.value = logins;

--- a/src/ConditionOptions/WhenFileContentConditionOptions.ts
+++ b/src/ConditionOptions/WhenFileContentConditionOptions.ts
@@ -1,3 +1,4 @@
+import { StringTestValue } from '../Types';
 import { BaseConditionOptions } from './BaseConditionOptions';
 import { WhenFileContentConditionOptionsValues } from './Values';
 
@@ -13,6 +14,12 @@ export class WhenFileContentConditionOptions extends BaseConditionOptions<WhenFi
   public onlyModifiedFiles(): WhenFileContentConditionOptions {
     this.values.onlyModifiedFiles = true;
     this.values.onlyNewFiles = false;
+
+    return this;
+  }
+
+  public excludePaths(test: StringTestValue): WhenFileContentConditionOptions {
+    this.values.excludePaths = test;
 
     return this;
   }

--- a/src/ConditionOptions/WhenFileContentConditionOptions.ts
+++ b/src/ConditionOptions/WhenFileContentConditionOptions.ts
@@ -24,4 +24,10 @@ export class WhenFileContentConditionOptions extends BaseConditionOptions<WhenFi
     return this;
   }
 
+  public includeOnlyPaths(test: StringTestValue): WhenFileContentConditionOptions {
+    this.values.includeOnlyPaths = test;
+
+    return this;
+  }
+
 }

--- a/src/ConditionOptions/WhenFileContentConditionOptions.ts
+++ b/src/ConditionOptions/WhenFileContentConditionOptions.ts
@@ -18,12 +18,20 @@ export class WhenFileContentConditionOptions extends BaseConditionOptions<WhenFi
     return this;
   }
 
+  /**
+   * Ignores paths to matching files.
+   * This option takes precedence over `includeOnlyPaths`.
+   */
   public excludePaths(test: StringTestValue): WhenFileContentConditionOptions {
     this.values.excludePaths = test;
 
     return this;
   }
 
+  /**
+   * Checks only matching files.
+   * If the path is excluded (`excludePaths`), then this option will not work.
+   */
   public includeOnlyPaths(test: StringTestValue): WhenFileContentConditionOptions {
     this.values.includeOnlyPaths = test;
 

--- a/src/ConditionOptions/WhenNumberConditionOptions.ts
+++ b/src/ConditionOptions/WhenNumberConditionOptions.ts
@@ -33,4 +33,13 @@ export class WhenNumberConditionOptions extends BaseConditionOptions<NumberCondi
     return this;
   }
 
+  public between(from: number, to: number): WhenNumberConditionOptions {
+    this.values.between = {
+      from,
+      to,
+    };
+
+    return this;
+  }
+
 }

--- a/src/ConditionOptions/index.ts
+++ b/src/ConditionOptions/index.ts
@@ -10,6 +10,7 @@ export {
 export { BaseConditionOptions } from './BaseConditionOptions';
 export { DefaultConditionOptions } from './DefaultConditionOptions';
 export { WhenCommentTextConditionOptions } from './WhenCommentTextConditionOptions';
+export { WhenContainsRequestsToReviewConditionOptions } from './WhenContainsRequestsToReviewConditionOptions';
 export { WhenFileContentConditionOptions } from './WhenFileContentConditionOptions';
 export { WhenFilePathConditionOptions } from './WhenFilePathConditionOptions';
 export { WhenInternalConditionOptions } from './WhenInternalConditionOptions';

--- a/src/Conditions/WhenCommentCountCondition.ts
+++ b/src/Conditions/WhenCommentCountCondition.ts
@@ -16,6 +16,7 @@ export class WhenCommentCountCondition extends BaseCondition<DefaultPredicateTyp
       greaterThanOrEqualTo,
       lessThan,
       lessThanOrEqualTo,
+      between,
     } = super.getOptions(context);
 
     const { comments: count } = await context.pullRequest.statusInfo.get();
@@ -38,6 +39,10 @@ export class WhenCommentCountCondition extends BaseCondition<DefaultPredicateTyp
     }
 
     if (lessThanOrEqualTo && count <= lessThanOrEqualTo) {
+      return this.testResult(true, context);
+    }
+
+    if (between && count >= between.from && count <= between.to) {
       return this.testResult(true, context);
     }
 

--- a/src/Conditions/WhenCommentCountCondition.ts
+++ b/src/Conditions/WhenCommentCountCondition.ts
@@ -1,4 +1,5 @@
 import { WhenNumberConditionOptions } from '../ConditionOptions';
+import { testNumberConditions } from '../Helpers';
 import { LabelerContext } from '../LabelerContext';
 import { DefaultPredicateType } from '../Types';
 import { BaseCondition } from './BaseCondition';
@@ -10,43 +11,15 @@ export class WhenCommentCountCondition extends BaseCondition<DefaultPredicateTyp
   }
 
   public async test(context: LabelerContext): Promise<boolean> {
-    const {
-      equal,
-      greaterThan,
-      greaterThanOrEqualTo,
-      lessThan,
-      lessThanOrEqualTo,
-      between,
-    } = super.getOptions(context);
+    const { comments } = await context.pullRequest.statusInfo.get();
 
-    const { comments: count } = await context.pullRequest.statusInfo.get();
-
-    // TODO: helper
-    if (equal && count === equal) {
-      return this.testResult(true, context);
-    }
-
-    if (greaterThan && count > greaterThan) {
-      return this.testResult(true, context);
-    }
-
-    if (greaterThanOrEqualTo && count >= greaterThanOrEqualTo) {
-      return this.testResult(true, context);
-    }
-
-    if (lessThan && count < lessThan) {
-      return this.testResult(true, context);
-    }
-
-    if (lessThanOrEqualTo && count <= lessThanOrEqualTo) {
-      return this.testResult(true, context);
-    }
-
-    if (between && count >= between.from && count <= between.to) {
-      return this.testResult(true, context);
-    }
-
-    return this.testResult(false, context);
+    return this.testResult(
+      testNumberConditions(
+        comments,
+        super.getOptions(context)
+      ),
+      context
+    );
   }
 
 }

--- a/src/Conditions/WhenCommitCountCondition.ts
+++ b/src/Conditions/WhenCommitCountCondition.ts
@@ -1,4 +1,5 @@
 import { WhenNumberConditionOptions } from '../ConditionOptions';
+import { testNumberConditions } from '../Helpers';
 import { LabelerContext } from '../LabelerContext';
 import { DefaultPredicateType } from '../Types';
 import { BaseCondition } from './BaseCondition';
@@ -10,43 +11,15 @@ export class WhenCommitCountCondition extends BaseCondition<DefaultPredicateType
   }
 
   public async test(context: LabelerContext): Promise<boolean> {
-    const {
-      equal,
-      greaterThan,
-      greaterThanOrEqualTo,
-      lessThan,
-      lessThanOrEqualTo,
-      between,
-    } = super.getOptions(context);
+    const { commits } = await context.pullRequest.statusInfo.get();
 
-    const { commits: count } = await context.pullRequest.statusInfo.get();
-
-    // TODO: helper
-    if (equal && count === equal) {
-      return this.testResult(true, context);
-    }
-
-    if (greaterThan && count > greaterThan) {
-      return this.testResult(true, context);
-    }
-
-    if (greaterThanOrEqualTo && count >= greaterThanOrEqualTo) {
-      return this.testResult(true, context);
-    }
-
-    if (lessThan && count < lessThan) {
-      return this.testResult(true, context);
-    }
-
-    if (lessThanOrEqualTo && count <= lessThanOrEqualTo) {
-      return this.testResult(true, context);
-    }
-
-    if (between && count >= between.from && count <= between.to) {
-      return this.testResult(true, context);
-    }
-
-    return this.testResult(false, context);
+    return this.testResult(
+      testNumberConditions(
+        commits,
+        super.getOptions(context)
+      ),
+      context
+    );
   }
 
 }

--- a/src/Conditions/WhenCommitCountCondition.ts
+++ b/src/Conditions/WhenCommitCountCondition.ts
@@ -16,6 +16,7 @@ export class WhenCommitCountCondition extends BaseCondition<DefaultPredicateType
       greaterThanOrEqualTo,
       lessThan,
       lessThanOrEqualTo,
+      between,
     } = super.getOptions(context);
 
     const { commits: count } = await context.pullRequest.statusInfo.get();
@@ -38,6 +39,10 @@ export class WhenCommitCountCondition extends BaseCondition<DefaultPredicateType
     }
 
     if (lessThanOrEqualTo && count <= lessThanOrEqualTo) {
+      return this.testResult(true, context);
+    }
+
+    if (between && count >= between.from && count <= between.to) {
       return this.testResult(true, context);
     }
 

--- a/src/Conditions/WhenContainsConflictsCondition.ts
+++ b/src/Conditions/WhenContainsConflictsCondition.ts
@@ -2,7 +2,7 @@ import { DefaultConditionOptions } from '../ConditionOptions';
 import { LabelerContext } from '../LabelerContext';
 import { BaseCondition } from './BaseCondition';
 
-export class WhenContainsConflicts extends BaseCondition<boolean, DefaultConditionOptions> {
+export class WhenContainsConflictsCondition extends BaseCondition<boolean, DefaultConditionOptions> {
 
   constructor(hasConflicts: boolean, options?: DefaultConditionOptions) {
     super(hasConflicts, options);

--- a/src/Conditions/WhenContainsRequestsToReview.ts
+++ b/src/Conditions/WhenContainsRequestsToReview.ts
@@ -1,0 +1,29 @@
+import { DefaultConditionOptions } from '../ConditionOptions';
+import { LabelerContext } from '../LabelerContext';
+import { BaseCondition } from './BaseCondition';
+
+export class WhenContainsRequestsToReview extends BaseCondition<boolean, DefaultConditionOptions> {
+
+  constructor(hasConflicts: boolean, options?: DefaultConditionOptions) {
+    super(hasConflicts, options);
+  }
+
+  public test(context: LabelerContext): boolean {
+    const {
+      requestedReviewers,
+    } = context.pullRequest;
+
+    if (this.predicate) {
+      return this.testResult(
+        requestedReviewers.length > 0,
+        context
+      );
+    } else {
+      return this.testResult(
+        requestedReviewers.length === 0,
+        context
+      );
+    }
+  }
+
+}

--- a/src/Conditions/WhenContainsRequestsToReviewCondition.ts
+++ b/src/Conditions/WhenContainsRequestsToReviewCondition.ts
@@ -2,7 +2,7 @@ import { DefaultConditionOptions } from '../ConditionOptions';
 import { LabelerContext } from '../LabelerContext';
 import { BaseCondition } from './BaseCondition';
 
-export class WhenContainsRequestsToReview extends BaseCondition<boolean, DefaultConditionOptions> {
+export class WhenContainsRequestsToReviewCondition extends BaseCondition<boolean, DefaultConditionOptions> {
 
   constructor(hasConflicts: boolean, options?: DefaultConditionOptions) {
     super(hasConflicts, options);

--- a/src/Conditions/WhenContainsRequestsToReviewCondition.ts
+++ b/src/Conditions/WhenContainsRequestsToReviewCondition.ts
@@ -1,17 +1,53 @@
-import { DefaultConditionOptions } from '../ConditionOptions';
+import { User } from '../ApiProviders';
+import { WhenContainsRequestsToReviewConditionOptions } from '../ConditionOptions';
 import { LabelerContext } from '../LabelerContext';
 import { BaseCondition } from './BaseCondition';
 
-export class WhenContainsRequestsToReviewCondition extends BaseCondition<boolean, DefaultConditionOptions> {
+export class WhenContainsRequestsToReviewCondition extends BaseCondition<boolean, WhenContainsRequestsToReviewConditionOptions> {
 
-  constructor(hasConflicts: boolean, options?: DefaultConditionOptions) {
+  constructor(hasConflicts: boolean, options?: WhenContainsRequestsToReviewConditionOptions) {
     super(hasConflicts, options);
   }
 
   public test(context: LabelerContext): boolean {
     const {
+      all,
+      oneOf,
+      value,
+    } = this.getOptions(context);
+
+    const users = [...value || []];
+    const hasUsers = !!users.length;
+
+    const {
       requestedReviewers,
     } = context.pullRequest;
+
+    if (hasUsers) {
+      if (oneOf) {
+        if (
+          requestedReviewers.filter(
+            (user: User): boolean => (
+              users.includes(user.login)
+            )
+          ).length === 0
+        ) {
+          return this.testResult(false, context);
+        }
+      }
+
+      if (all) {
+        if (
+          !requestedReviewers.every(
+            (user: User): boolean => (
+              users.includes(user.login)
+            )
+          )
+        ) {
+          return this.testResult(false, context);
+        }
+      }
+    }
 
     if (this.predicate) {
       return this.testResult(

--- a/src/Conditions/WhenFileContentCondition.ts
+++ b/src/Conditions/WhenFileContentCondition.ts
@@ -13,6 +13,7 @@ export class WhenFileContentCondition extends BaseCondition<DefaultPredicateType
     const {
       onlyModifiedFiles,
       onlyNewFiles,
+      excludePaths,
     } = this.getOptions(context);
 
     const files = await context.pullRequest.files.get();
@@ -20,6 +21,10 @@ export class WhenFileContentCondition extends BaseCondition<DefaultPredicateType
     let result = false;
 
     for (const file of files) {
+      if (excludePaths && this.testStringValue(file.filePath, context, excludePaths)) {
+        continue;
+      }
+
       if (onlyModifiedFiles && file.status !== 'modified') {
         continue;
       }

--- a/src/Conditions/WhenFileContentCondition.ts
+++ b/src/Conditions/WhenFileContentCondition.ts
@@ -14,6 +14,7 @@ export class WhenFileContentCondition extends BaseCondition<DefaultPredicateType
       onlyModifiedFiles,
       onlyNewFiles,
       excludePaths,
+      includeOnlyPaths,
     } = this.getOptions(context);
 
     const files = await context.pullRequest.files.get();
@@ -22,6 +23,10 @@ export class WhenFileContentCondition extends BaseCondition<DefaultPredicateType
 
     for (const file of files) {
       if (excludePaths && this.testStringValue(file.filePath, context, excludePaths)) {
+        continue;
+      }
+
+      if (includeOnlyPaths && !this.testStringValue(file.filePath, context, includeOnlyPaths)) {
         continue;
       }
 

--- a/src/Conditions/WhenFileCountCondition.ts
+++ b/src/Conditions/WhenFileCountCondition.ts
@@ -16,10 +16,12 @@ export class WhenFileCountCondition extends BaseCondition<DefaultPredicateType, 
       greaterThanOrEqualTo,
       lessThan,
       lessThanOrEqualTo,
+      between,
     } = super.getOptions(context);
 
     const { changedFiles } = await context.pullRequest.statusInfo.get();
 
+    // TODO: helper
     if (equal && changedFiles === equal) {
       return this.testResult(true, context);
     }
@@ -37,6 +39,10 @@ export class WhenFileCountCondition extends BaseCondition<DefaultPredicateType, 
     }
 
     if (lessThanOrEqualTo && changedFiles <= lessThanOrEqualTo) {
+      return this.testResult(true, context);
+    }
+
+    if (between && changedFiles >= between.from && changedFiles <= between.to) {
       return this.testResult(true, context);
     }
 

--- a/src/Conditions/WhenFileCountCondition.ts
+++ b/src/Conditions/WhenFileCountCondition.ts
@@ -1,4 +1,5 @@
 import { WhenNumberConditionOptions } from '../ConditionOptions';
+import { testNumberConditions } from '../Helpers';
 import { LabelerContext } from '../LabelerContext';
 import { DefaultPredicateType } from '../Types';
 import { BaseCondition } from './BaseCondition';
@@ -10,43 +11,15 @@ export class WhenFileCountCondition extends BaseCondition<DefaultPredicateType, 
   }
 
   public async test(context: LabelerContext): Promise<boolean> {
-    const {
-      equal,
-      greaterThan,
-      greaterThanOrEqualTo,
-      lessThan,
-      lessThanOrEqualTo,
-      between,
-    } = super.getOptions(context);
-
     const { changedFiles } = await context.pullRequest.statusInfo.get();
 
-    // TODO: helper
-    if (equal && changedFiles === equal) {
-      return this.testResult(true, context);
-    }
-
-    if (greaterThan && changedFiles > greaterThan) {
-      return this.testResult(true, context);
-    }
-
-    if (greaterThanOrEqualTo && changedFiles >= greaterThanOrEqualTo) {
-      return this.testResult(true, context);
-    }
-
-    if (lessThan && changedFiles < lessThan) {
-      return this.testResult(true, context);
-    }
-
-    if (lessThanOrEqualTo && changedFiles <= lessThanOrEqualTo) {
-      return this.testResult(true, context);
-    }
-
-    if (between && changedFiles >= between.from && changedFiles <= between.to) {
-      return this.testResult(true, context);
-    }
-
-    return this.testResult(false, context);
+    return this.testResult(
+      testNumberConditions(
+        changedFiles,
+        super.getOptions(context)
+      ),
+      context
+    );
   }
 
 }

--- a/src/Conditions/WhenStateCondition.ts
+++ b/src/Conditions/WhenStateCondition.ts
@@ -4,7 +4,7 @@ import { BaseCondition } from './BaseCondition';
 
 type PullRequestState = 'open' | 'closed' | 'merged';
 
-export class WhenState extends BaseCondition<PullRequestState, DefaultConditionOptions> {
+export class WhenStateCondition extends BaseCondition<PullRequestState, DefaultConditionOptions> {
 
   constructor(state: PullRequestState, options?: DefaultConditionOptions) {
     super(state, options);

--- a/src/Conditions/index.ts
+++ b/src/Conditions/index.ts
@@ -9,6 +9,7 @@ export { WhenCommitCountCondition } from './WhenCommitCountCondition';
 export { WhenCommitMessageCondition } from './WhenCommitMessageCondition';
 export { WhenCondition } from './WhenCondition';
 export { WhenContainsConflicts } from './WhenContainsConflicts';
+export { WhenContainsRequestsToReview } from './WhenContainsRequestsToReview';
 export { WhenDescriptionCondition } from './WhenDescriptionCondition';
 export { WhenFileContentCondition } from './WhenFileContentCondition';
 export { WhenFileCountCondition } from './WhenFileCountCondition';

--- a/src/Conditions/index.ts
+++ b/src/Conditions/index.ts
@@ -20,6 +20,6 @@ export { WhenMergeDirectionCondition } from './WhenMergeDirectionCondition';
 export { WhenMilestoneNameCondition } from './WhenMilestoneNameCondition';
 export { WhenReviewStateCondition } from './WhenReviewStateCondition';
 export { WhenSourceBranchNameCondition } from './WhenSourceBranchNameCondition';
-export { WhenState } from './WhenState';
+export { WhenStateCondition } from './WhenStateCondition';
 export { WhenTargetBranchNameCondition } from './WhenTargetBranchNameCondition';
 export { WhenTitleCondition } from './WhenTitleCondition';

--- a/src/Conditions/index.ts
+++ b/src/Conditions/index.ts
@@ -8,7 +8,7 @@ export { WhenCommentTextCondition } from './WhenCommentTextCondition';
 export { WhenCommitCountCondition } from './WhenCommitCountCondition';
 export { WhenCommitMessageCondition } from './WhenCommitMessageCondition';
 export { WhenCondition } from './WhenCondition';
-export { WhenContainsConflicts } from './WhenContainsConflicts';
+export { WhenContainsConflictsCondition } from './WhenContainsConflictsCondition';
 export { WhenContainsRequestsToReviewCondition } from './WhenContainsRequestsToReviewCondition';
 export { WhenDescriptionCondition } from './WhenDescriptionCondition';
 export { WhenFileContentCondition } from './WhenFileContentCondition';

--- a/src/Conditions/index.ts
+++ b/src/Conditions/index.ts
@@ -9,7 +9,7 @@ export { WhenCommitCountCondition } from './WhenCommitCountCondition';
 export { WhenCommitMessageCondition } from './WhenCommitMessageCondition';
 export { WhenCondition } from './WhenCondition';
 export { WhenContainsConflicts } from './WhenContainsConflicts';
-export { WhenContainsRequestsToReview } from './WhenContainsRequestsToReview';
+export { WhenContainsRequestsToReviewCondition } from './WhenContainsRequestsToReviewCondition';
 export { WhenDescriptionCondition } from './WhenDescriptionCondition';
 export { WhenFileContentCondition } from './WhenFileContentCondition';
 export { WhenFileCountCondition } from './WhenFileCountCondition';

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -113,7 +113,7 @@ class Config implements IConfig, IActionCollection, ILinkingActions {
     );
   }
 
-  public requestReviewers(usernames: Array<string> | { (context?: LabelerContext): Array<string> }): IAction {
+  public requestReviewers(usernames: string | Array<string> | { (context?: LabelerContext): Array<string> }): IAction {
     return this.addAction(
       new RequestReviewersActionExecutor(
         new RequestReviewersAction(usernames, this),

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -122,7 +122,7 @@ class Config implements IConfig, IActionCollection, ILinkingActions {
     );
   }
 
-  public removeRequestedReviewers(usernames: Array<string> | { (context?: LabelerContext): Array<string> }): IAction {
+  public removeRequestedReviewers(usernames: string | Array<string> | { (context?: LabelerContext): Array<string> }): IAction {
     return this.addAction(
       new RemoveRequestedReviewersActionExecutor(
         new RemoveRequestedReviewersAction(usernames, this),

--- a/src/Helpers/CheckValuesHelpers.ts
+++ b/src/Helpers/CheckValuesHelpers.ts
@@ -1,0 +1,51 @@
+import { NumberConditionOptionsValues } from '../ConditionOptions';
+
+export function testNumberConditions(count: number, options: NumberConditionOptionsValues): boolean {
+  const {
+    equal,
+    greaterThan,
+    greaterThanOrEqualTo,
+    lessThan,
+    lessThanOrEqualTo,
+    between,
+  } = options;
+
+  let result = [
+    equal,
+    greaterThan,
+    greaterThanOrEqualTo,
+    lessThan,
+    lessThanOrEqualTo,
+    between,
+  ].some(hasValue);
+
+  if (result && hasValue(equal)) {
+    result = count === equal;
+  }
+
+  if (result && hasValue(greaterThan)) {
+    result = count > greaterThan;
+  }
+
+  if (result && hasValue(greaterThanOrEqualTo)) {
+    result = count >= greaterThanOrEqualTo;
+  }
+
+  if (result && hasValue(lessThan)) {
+    result = count < lessThan;
+  }
+
+  if (result && hasValue(lessThanOrEqualTo)) {
+    result = count <= lessThanOrEqualTo;
+  }
+
+  if (result && hasValue(between)) {
+    result = count >= between.from && count <= between.to;
+  }
+
+  return result;
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null;
+}

--- a/src/Helpers/index.ts
+++ b/src/Helpers/index.ts
@@ -1,0 +1,1 @@
+export { testNumberConditions } from './CheckValuesHelpers';

--- a/src/Interfaces/IAction.ts
+++ b/src/Interfaces/IAction.ts
@@ -118,6 +118,16 @@ export interface IAction {
   whenHasNoConflicts(): DefaultConditionOptions;
 
   /**
+   * Checks that there are requests to reviewers in a pull request.
+   */
+  whenHasRequestsToReview(): DefaultConditionOptions;
+
+  /**
+   * Checks that there are no requests to reviewers in a pull request.
+   */
+  whenHasNoRequestsToReview(): DefaultConditionOptions;
+
+  /**
    * Checks that a pull request was not reviewed
    * (has no code review comments, has not been approved or requested changes).
    */

--- a/src/Interfaces/IAction.ts
+++ b/src/Interfaces/IAction.ts
@@ -1,6 +1,7 @@
 import {
   DefaultConditionOptions,
   WhenCommentTextConditionOptions,
+  WhenContainsRequestsToReviewConditionOptions,
   WhenFileContentConditionOptions,
   WhenFilePathConditionOptions,
   WhenNumberConditionOptions,
@@ -120,12 +121,12 @@ export interface IAction {
   /**
    * Checks that there are requests to reviewers in a pull request.
    */
-  whenHasRequestsToReview(): DefaultConditionOptions;
+  whenHasRequestsToReview(): WhenContainsRequestsToReviewConditionOptions;
 
   /**
    * Checks that there are no requests to reviewers in a pull request.
    */
-  whenHasNoRequestsToReview(): DefaultConditionOptions;
+  whenHasNoRequestsToReview(): WhenContainsRequestsToReviewConditionOptions;
 
   /**
    * Checks that a pull request was not reviewed

--- a/src/Interfaces/IConfig.ts
+++ b/src/Interfaces/IConfig.ts
@@ -64,7 +64,7 @@ export interface IConfig {
   /**
    * Requests a code review from the specified users.
    */
-  requestReviewers(usernames: Array<string> | { (context?: LabelerContext): Array<string> }): IAction;
+  requestReviewers(usernames: string | Array<string> | { (context?: LabelerContext): Array<string> }): IAction;
 
   /**
    * Removes the code review request for the specified users.

--- a/src/Interfaces/IConfig.ts
+++ b/src/Interfaces/IConfig.ts
@@ -69,7 +69,7 @@ export interface IConfig {
   /**
    * Removes the code review request for the specified users.
    */
-  removeRequestedReviewers(usernames: Array<string> | { (context?: LabelerContext): Array<string> }): IAction;
+  removeRequestedReviewers(usernames: string | Array<string> | { (context?: LabelerContext): Array<string> }): IAction;
 
   /**
    * Deletes the source branch. ATTENTION: This action cannot be undone!

--- a/tests/BaseActionTest.ts
+++ b/tests/BaseActionTest.ts
@@ -10,7 +10,7 @@ import {
   WhenCommitMessageCondition,
   WhenCondition,
   WhenContainsConflicts,
-  WhenContainsRequestsToReview,
+  WhenContainsRequestsToReviewCondition,
   WhenDescriptionCondition,
   WhenFileContentCondition,
   WhenFileCountCondition,
@@ -247,7 +247,7 @@ describe('BaseAction', () => {
     action.whenHasRequestsToReview();
 
     expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReview);
+    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReviewCondition);
   });
 
   it('whenHasNoRequestsToReview', (): void => {
@@ -257,7 +257,7 @@ describe('BaseAction', () => {
     action.whenHasNoRequestsToReview();
 
     expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReview);
+    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReviewCondition);
   });
 
   it('whenNotReviewed', (): void => {

--- a/tests/BaseActionTest.ts
+++ b/tests/BaseActionTest.ts
@@ -10,6 +10,7 @@ import {
   WhenCommitMessageCondition,
   WhenCondition,
   WhenContainsConflicts,
+  WhenContainsRequestsToReview,
   WhenDescriptionCondition,
   WhenFileContentCondition,
   WhenFileCountCondition,
@@ -237,6 +238,26 @@ describe('BaseAction', () => {
 
     expect(action.conditions.length).to.be.equal(1);
     expect(action.conditions[0]).to.be.instanceof(WhenTitleCondition);
+  });
+
+  it('whenHasRequestsToReview', (): void => {
+    const config = createConfig();
+    const action = config.addLabel('test') as BaseAction;
+
+    action.whenHasRequestsToReview();
+
+    expect(action.conditions.length).to.be.equal(1);
+    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReview);
+  });
+
+  it('whenHasNoRequestsToReview', (): void => {
+    const config = createConfig();
+    const action = config.addLabel('test') as BaseAction;
+
+    action.whenHasNoRequestsToReview();
+
+    expect(action.conditions.length).to.be.equal(1);
+    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReview);
   });
 
   it('whenNotReviewed', (): void => {

--- a/tests/BaseActionTest.ts
+++ b/tests/BaseActionTest.ts
@@ -9,7 +9,7 @@ import {
   WhenCommitCountCondition,
   WhenCommitMessageCondition,
   WhenCondition,
-  WhenContainsConflicts,
+  WhenContainsConflictsCondition,
   WhenContainsRequestsToReviewCondition,
   WhenDescriptionCondition,
   WhenFileContentCondition,
@@ -167,7 +167,7 @@ describe('BaseAction', () => {
     action.whenHasConflicts();
 
     expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsConflicts);
+    expect(action.conditions[0]).to.be.instanceof(WhenContainsConflictsCondition);
   });
 
   it('whenHasNoConflicts', (): void => {
@@ -177,7 +177,7 @@ describe('BaseAction', () => {
     action.whenHasNoConflicts();
 
     expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsConflicts);
+    expect(action.conditions[0]).to.be.instanceof(WhenContainsConflictsCondition);
   });
 
   it('whenLabel', (): void => {

--- a/tests/BaseActionTest.ts
+++ b/tests/BaseActionTest.ts
@@ -21,7 +21,7 @@ import {
   WhenMilestoneNameCondition,
   WhenReviewStateCondition,
   WhenSourceBranchNameCondition,
-  WhenState,
+  WhenStateCondition,
   WhenTargetBranchNameCondition,
   WhenTitleCondition,
 } from '../src/Conditions';
@@ -297,7 +297,7 @@ describe('BaseAction', () => {
     action.whenOpen();
 
     expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenState);
+    expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
   });
 
   it('whenClosed', (): void => {
@@ -307,7 +307,7 @@ describe('BaseAction', () => {
     action.whenClosed();
 
     expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenState);
+    expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
   });
 
   it('whenWasMerged', (): void => {
@@ -317,7 +317,7 @@ describe('BaseAction', () => {
     action.whenWasMerged();
 
     expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenState);
+    expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
   });
 
   it('then', (): void => {

--- a/tests/BaseActionTest.ts
+++ b/tests/BaseActionTest.ts
@@ -27,8 +27,1187 @@ import {
 } from '../src/Conditions';
 import { createConfig } from '../src/Config';
 import { IActionCollection } from '../src/Interfaces';
+import { LabelerContext } from '../src/LabelerContext';
+import { firstPullRequest, flossTomUser, secondPullRequest } from './Resources';
 
 describe('BaseAction', () => {
+
+  describe('when', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .when(() => true);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .when(() => true);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .when(() => true)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenAuthorLogin', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenAuthorLogin(flossTomUser.login);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenAuthorLoginCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenAuthorLogin(flossTomUser.login);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenAuthorLogin(flossTomUser.login)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenCommentCount', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommentCount();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenCommentCountCondition);
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommentCount()
+        .equal((await firstPullRequest.comments.get()).length);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenCommentText', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommentText('test');
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenCommentTextCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommentText('Well done!');
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommentText('Well done!')
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenCommitCount', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommitCount();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenCommitCountCondition);
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommitCount()
+        .equal((await firstPullRequest.commits.get()).length);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenCommitMessage', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommitMessage('awesome bug');
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenCommitMessageCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommitMessage('awesome bug');
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenCommitMessage('awesome bug')
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenDescription', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescription('test');
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenDescriptionCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescription(firstPullRequest.description);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescription(firstPullRequest.description)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenDescriptionIsEmpty', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescriptionIsEmpty();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenDescriptionCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescriptionIsEmpty();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescriptionIsEmpty()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenDescriptionIsNotEmpty', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescriptionIsNotEmpty();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenDescriptionCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescriptionIsNotEmpty();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenDescriptionIsNotEmpty()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenFileContent', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFileContent('AwesomeComponent');
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenFileContentCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFileContent('AwesomeComponent');
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFileContent('AwesomeComponent')
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenFileCount', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFileCount();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenFileCountCondition);
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFileCount()
+        .equal((await firstPullRequest.files.get()).length);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenFilePath', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFilePath(/\.cs$/);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenFilePathCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFilePath(/\.cs$/);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenFilePath(/\.cs$/)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenHasConflicts', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasConflicts();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenContainsConflictsCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasConflicts();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasConflicts()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenHasNoConflicts', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasNoConflicts();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenContainsConflictsCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasNoConflicts();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasNoConflicts()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenLabel', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenLabel(firstPullRequest.labels[0]);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenLabelCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenLabel(firstPullRequest.labels[0]);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenLabel(firstPullRequest.labels[0])
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenMergeDirection', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenMergeDirection([{
+          from: firstPullRequest.sourceBranch.name,
+          to: firstPullRequest.targetBranch.name,
+        }]);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenMergeDirectionCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenMergeDirection([{
+          from: firstPullRequest.sourceBranch.name,
+          to: firstPullRequest.targetBranch.name,
+        }]);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenMergeDirection([{
+          from: firstPullRequest.sourceBranch.name,
+          to: firstPullRequest.targetBranch.name,
+        }])
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenMilestoneName', () => {
+    const context = new LabelerContext({
+      pullRequest: secondPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenMilestoneName(secondPullRequest.milestone.name);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenMilestoneNameCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenMilestoneName(secondPullRequest.milestone.name);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenMilestoneName(secondPullRequest.milestone.name)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenSourceBranchName', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenSourceBranchName(firstPullRequest.sourceBranch.name);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenSourceBranchNameCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenSourceBranchName(firstPullRequest.sourceBranch.name);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenSourceBranchName(firstPullRequest.sourceBranch.name)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenTargetBranchName', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenTargetBranchName(firstPullRequest.targetBranch.name);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenTargetBranchNameCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenTargetBranchName(firstPullRequest.targetBranch.name);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenTargetBranchName(firstPullRequest.targetBranch.name)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenTitle', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenTitle(firstPullRequest.title);
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenTitleCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenTitle(firstPullRequest.title);
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenTitle(firstPullRequest.title)
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenHasRequestsToReview', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasRequestsToReview();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReviewCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasRequestsToReview();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasRequestsToReview()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenHasNoRequestsToReview', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasNoRequestsToReview();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReviewCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasNoRequestsToReview();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenHasNoRequestsToReview()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenNotReviewed', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenNotReviewed();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenReviewStateCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenNotReviewed();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenNotReviewed()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenApproved', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenApproved();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenReviewStateCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenApproved();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenApproved()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenChangesRequested', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenChangesRequested();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenReviewStateCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenChangesRequested();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenChangesRequested()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenOpen', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenOpen();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenOpen();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenOpen()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('whenClosed', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenClosed();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenClosed();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenClosed()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('whenWasMerged', () => {
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    it('type', (): void => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenWasMerged();
+
+      expect(action.conditions.length).to.be.equal(1);
+      expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
+    });
+
+    it('result without options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenWasMerged();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.false;
+    });
+
+    it('result with options', async(): Promise<void> => {
+      const config = createConfig();
+      const action = config.addLabel('test') as BaseAction;
+
+      action
+        .whenWasMerged()
+        .nothing();
+
+      const result = await action.conditions[0].test(context);
+
+      expect(result).to.be.true;
+    });
+  });
 
   it('ignoreOthers', (): void => {
     const config = createConfig();
@@ -38,286 +1217,6 @@ describe('BaseAction', () => {
 
     expect(action.conditions.length).to.be.equal(1);
     expect(action.conditions[0]).to.be.instanceof(WhenInternalCondition);
-  });
-
-  it('when', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.when(() => true);
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenCondition);
-  });
-
-  it('whenAuthorLogin', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenAuthorLogin('username');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenAuthorLoginCondition);
-  });
-
-  it('whenCommentCount', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenCommentCount();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenCommentCountCondition);
-  });
-
-  it('whenCommentText', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenCommentText('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenCommentTextCondition);
-  });
-
-  it('whenCommitCount', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenCommitCount();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenCommitCountCondition);
-  });
-
-  it('whenCommitMessage', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenCommitMessage('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenCommitMessageCondition);
-  });
-
-  it('whenDescription', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenDescription('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenDescriptionCondition);
-  });
-
-  it('whenDescriptionIsEmpty', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenDescriptionIsEmpty();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenDescriptionCondition);
-  });
-
-  it('whenDescriptionIsNotEmpty', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenDescriptionIsNotEmpty();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenDescriptionCondition);
-  });
-
-  it('whenFileContent', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenFileContent('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenFileContentCondition);
-  });
-
-  it('whenFileCount', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenFileCount();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenFileCountCondition);
-  });
-
-  it('whenFilePath', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenFilePath('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenFilePathCondition);
-  });
-
-  it('whenHasConflicts', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenHasConflicts();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsConflictsCondition);
-  });
-
-  it('whenHasNoConflicts', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenHasNoConflicts();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsConflictsCondition);
-  });
-
-  it('whenLabel', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenLabel('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenLabelCondition);
-  });
-
-  it('whenMergeDirection', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenMergeDirection([{ from: 'source', to: 'target' }]);
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenMergeDirectionCondition);
-  });
-
-  it('whenMilestoneName', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenMilestoneName('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenMilestoneNameCondition);
-  });
-
-  it('whenSourceBranchName', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenSourceBranchName('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenSourceBranchNameCondition);
-  });
-
-  it('whenTargetBranchName', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenTargetBranchName('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenTargetBranchNameCondition);
-  });
-
-  it('whenTitle', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenTitle('test');
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenTitleCondition);
-  });
-
-  it('whenHasRequestsToReview', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenHasRequestsToReview();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReviewCondition);
-  });
-
-  it('whenHasNoRequestsToReview', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenHasNoRequestsToReview();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenContainsRequestsToReviewCondition);
-  });
-
-  it('whenNotReviewed', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('awaiting review') as BaseAction;
-
-    action.whenNotReviewed();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenReviewStateCondition);
-  });
-
-  it('whenApproved', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('approved') as BaseAction;
-
-    action.whenApproved();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenReviewStateCondition);
-  });
-
-  it('whenChangesRequested', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('changes requested') as BaseAction;
-
-    action.whenChangesRequested();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenReviewStateCondition);
-  });
-
-  it('whenOpen', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenOpen();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
-  });
-
-  it('whenClosed', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenClosed();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
-  });
-
-  it('whenWasMerged', (): void => {
-    const config = createConfig();
-    const action = config.addLabel('test') as BaseAction;
-
-    action.whenWasMerged();
-
-    expect(action.conditions.length).to.be.equal(1);
-    expect(action.conditions[0]).to.be.instanceof(WhenStateCondition);
   });
 
   it('then', (): void => {

--- a/tests/Conditions/WhenContainsConflictsConditionTest.ts
+++ b/tests/Conditions/WhenContainsConflictsConditionTest.ts
@@ -2,17 +2,17 @@ import { expect, should, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import { DefaultConditionOptions } from '../../src/ConditionOptions';
-import { WhenContainsConflicts } from '../../src/Conditions';
+import { WhenContainsConflictsCondition } from '../../src/Conditions';
 import { LabelerContext } from '../../src/LabelerContext';
 import { firstPullRequest, secondPullRequests } from '../Resources';
 
 use(chaiAsPromised);
 should();
 
-describe('WhenContainsConflicts', () => {
+describe('WhenContainsConflictsCondition', () => {
 
   it('should return true for a pull request that does not contain conflicts', async(): Promise<void> => {
-    const when = new WhenContainsConflicts(false);
+    const when = new WhenContainsConflictsCondition(false);
     const context = new LabelerContext({
       pullRequest: firstPullRequest,
       test: true,
@@ -23,7 +23,7 @@ describe('WhenContainsConflicts', () => {
   });
 
   it('should return false for a pull request that does not contain conflicts', async(): Promise<void> => {
-    const when = new WhenContainsConflicts(true);
+    const when = new WhenContainsConflictsCondition(true);
     const context = new LabelerContext({
       pullRequest: firstPullRequest,
       test: true,
@@ -34,7 +34,7 @@ describe('WhenContainsConflicts', () => {
   });
 
   it('should return true for a pull request that contains conflicts', async(): Promise<void> => {
-    const when = new WhenContainsConflicts(true);
+    const when = new WhenContainsConflictsCondition(true);
     const context = new LabelerContext({
       pullRequest: secondPullRequests,
       test: true,
@@ -45,7 +45,7 @@ describe('WhenContainsConflicts', () => {
   });
 
   it('should return false for a pull request that contains conflicts', async(): Promise<void> => {
-    const when = new WhenContainsConflicts(false);
+    const when = new WhenContainsConflictsCondition(false);
     const context = new LabelerContext({
       pullRequest: secondPullRequests,
       test: true,
@@ -57,7 +57,7 @@ describe('WhenContainsConflicts', () => {
 
   it('should return false for a pull request that contains conflicts', async(): Promise<void> => {
     const options = new DefaultConditionOptions(null);
-    const when = new WhenContainsConflicts(true, options);
+    const when = new WhenContainsConflictsCondition(true, options);
 
     options.nothing();
 

--- a/tests/Conditions/WhenContainsConflictsConditionTest.ts
+++ b/tests/Conditions/WhenContainsConflictsConditionTest.ts
@@ -4,7 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { DefaultConditionOptions } from '../../src/ConditionOptions';
 import { WhenContainsConflictsCondition } from '../../src/Conditions';
 import { LabelerContext } from '../../src/LabelerContext';
-import { firstPullRequest, secondPullRequests } from '../Resources';
+import { firstPullRequest, secondPullRequest } from '../Resources';
 
 use(chaiAsPromised);
 should();
@@ -36,7 +36,7 @@ describe('WhenContainsConflictsCondition', () => {
   it('should return true for a pull request that contains conflicts', async(): Promise<void> => {
     const when = new WhenContainsConflictsCondition(true);
     const context = new LabelerContext({
-      pullRequest: secondPullRequests,
+      pullRequest: secondPullRequest,
       test: true,
     });
     const result = await when.test(context);
@@ -47,7 +47,7 @@ describe('WhenContainsConflictsCondition', () => {
   it('should return false for a pull request that contains conflicts', async(): Promise<void> => {
     const when = new WhenContainsConflictsCondition(false);
     const context = new LabelerContext({
-      pullRequest: secondPullRequests,
+      pullRequest: secondPullRequest,
       test: true,
     });
     const result = await when.test(context);
@@ -62,7 +62,7 @@ describe('WhenContainsConflictsCondition', () => {
     options.nothing();
 
     const context = new LabelerContext({
-      pullRequest: secondPullRequests,
+      pullRequest: secondPullRequest,
       test: true,
     });
     const result = await when.test(context);

--- a/tests/Conditions/WhenContainsRequestsToReviewConditionTest.ts
+++ b/tests/Conditions/WhenContainsRequestsToReviewConditionTest.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
-import { DefaultConditionOptions } from '../../src/ConditionOptions';
+import { WhenContainsRequestsToReviewConditionOptions } from '../../src/ConditionOptions';
 import { WhenContainsRequestsToReviewCondition } from '../../src/Conditions';
 import { LabelerContext } from '../../src/LabelerContext';
-import { firstPullRequest, noReviewPullRequest } from '../Resources';
+import { firstPullRequest, flossMotUser, loftSomsUser, msSoftLoUser, noReviewPullRequest } from '../Resources';
 
 describe('WhenContainsRequestsToReviewCondition', () => {
 
@@ -41,7 +41,7 @@ describe('WhenContainsRequestsToReviewCondition', () => {
   });
 
   it('should return true for a pull request that contains requests to reviewers when reviewers are expected and used the "nothing" option', (): void => {
-    const options = new DefaultConditionOptions(null);
+    const options = new WhenContainsRequestsToReviewConditionOptions(null);
     const when = new WhenContainsRequestsToReviewCondition(true, options);
 
     options.nothing();
@@ -53,6 +53,97 @@ describe('WhenContainsRequestsToReviewCondition', () => {
     const result = when.test(context);
 
     expect(result).to.be.false;
+  });
+
+  it('should return true for a pull request that contains requests to one of the reviewers when reviewers are expected', (): void => {
+    const options = new WhenContainsRequestsToReviewConditionOptions(null);
+    const when = new WhenContainsRequestsToReviewCondition(true, options);
+    const context = new LabelerContext({
+      pullRequest: noReviewPullRequest,
+      test: true,
+    });
+
+    options.oneOf([
+      flossMotUser.login,
+      loftSomsUser.login,
+    ]);
+
+    const result = when.test(context);
+
+    expect(result).to.be.true;
+  });
+
+  it('should return false for a pull request that no contains requests to a specific one of the reviewers when reviewers are expected', (): void => {
+    const options = new WhenContainsRequestsToReviewConditionOptions(null);
+    const when = new WhenContainsRequestsToReviewCondition(true, options);
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+
+    options.oneOf([
+      flossMotUser.login,
+    ]);
+
+    const result = when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return true for a pull request that contains requests to specific reviewers when reviewers are expected', (): void => {
+    const options = new WhenContainsRequestsToReviewConditionOptions(null);
+    const when = new WhenContainsRequestsToReviewCondition(true, options);
+    const context = new LabelerContext({
+      pullRequest: noReviewPullRequest,
+      test: true,
+    });
+
+    options.all([
+      flossMotUser.login,
+      loftSomsUser.login,
+    ]);
+
+    const result = when.test(context);
+
+    expect(result).to.be.true;
+  });
+
+  it('should return false for a pull request that contains requests to specific reviewers when reviewers are expected and one is missing', (): void => {
+    const options = new WhenContainsRequestsToReviewConditionOptions(null);
+    const when = new WhenContainsRequestsToReviewCondition(true, options);
+    const context = new LabelerContext({
+      pullRequest: noReviewPullRequest,
+      test: true,
+    });
+
+    options.all([
+      flossMotUser.login,
+      msSoftLoUser.login,
+    ]);
+
+    const result = when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return true for a pull request that contains requests to specific reviewers when reviewers are expected and one is missing with the "nothing" option', (): void => {
+    const options = new WhenContainsRequestsToReviewConditionOptions(null);
+    const when = new WhenContainsRequestsToReviewCondition(true, options);
+    const context = new LabelerContext({
+      pullRequest: noReviewPullRequest,
+      test: true,
+    });
+
+    options.all([
+      flossMotUser.login,
+      msSoftLoUser.login,
+    ]);
+
+    options.nothing();
+
+    const result = when.test(context);
+
+    expect(result).to.be.true;
   });
 
 });

--- a/tests/Conditions/WhenContainsRequestsToReviewConditionTest.ts
+++ b/tests/Conditions/WhenContainsRequestsToReviewConditionTest.ts
@@ -5,7 +5,7 @@ import { WhenContainsRequestsToReviewCondition } from '../../src/Conditions';
 import { LabelerContext } from '../../src/LabelerContext';
 import { firstPullRequest, noReviewPullRequest } from '../Resources';
 
-describe('WhenContainsRequestsToReview', () => {
+describe('WhenContainsRequestsToReviewCondition', () => {
 
   it('should return true for a pull request that contains requests to reviewers when reviewers are expected', (): void => {
     const when = new WhenContainsRequestsToReviewCondition(true);

--- a/tests/Conditions/WhenContainsRequestsToReviewTest.ts
+++ b/tests/Conditions/WhenContainsRequestsToReviewTest.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+
+import { DefaultConditionOptions } from '../../src/ConditionOptions';
+import { WhenContainsRequestsToReview } from '../../src/Conditions';
+import { LabelerContext } from '../../src/LabelerContext';
+import { firstPullRequest, noReviewPullRequest } from '../Resources';
+
+describe('WhenContainsRequestsToReview', () => {
+
+  it('should return true for a pull request that contains requests to reviewers when reviewers are expected', (): void => {
+    const when = new WhenContainsRequestsToReview(true);
+    const context = new LabelerContext({
+      pullRequest: noReviewPullRequest,
+      test: true,
+    });
+    const result = when.test(context);
+
+    expect(result).to.be.true;
+  });
+
+  it('should return false for a pull request that not contains requests to reviewers when reviewers are expected', (): void => {
+    const when = new WhenContainsRequestsToReview(true);
+    const context = new LabelerContext({
+      pullRequest: firstPullRequest,
+      test: true,
+    });
+    const result = when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return false for a pull request that contains requests to reviewers when no reviewers are expected', (): void => {
+    const when = new WhenContainsRequestsToReview(false);
+    const context = new LabelerContext({
+      pullRequest: noReviewPullRequest,
+      test: true,
+    });
+    const result = when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return true for a pull request that contains requests to reviewers when reviewers are expected and used the "nothing" option', (): void => {
+    const options = new DefaultConditionOptions(null);
+    const when = new WhenContainsRequestsToReview(true, options);
+
+    options.nothing();
+
+    const context = new LabelerContext({
+      pullRequest: noReviewPullRequest,
+      test: true,
+    });
+    const result = when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+});

--- a/tests/Conditions/WhenContainsRequestsToReviewTest.ts
+++ b/tests/Conditions/WhenContainsRequestsToReviewTest.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 
 import { DefaultConditionOptions } from '../../src/ConditionOptions';
-import { WhenContainsRequestsToReview } from '../../src/Conditions';
+import { WhenContainsRequestsToReviewCondition } from '../../src/Conditions';
 import { LabelerContext } from '../../src/LabelerContext';
 import { firstPullRequest, noReviewPullRequest } from '../Resources';
 
 describe('WhenContainsRequestsToReview', () => {
 
   it('should return true for a pull request that contains requests to reviewers when reviewers are expected', (): void => {
-    const when = new WhenContainsRequestsToReview(true);
+    const when = new WhenContainsRequestsToReviewCondition(true);
     const context = new LabelerContext({
       pullRequest: noReviewPullRequest,
       test: true,
@@ -19,7 +19,7 @@ describe('WhenContainsRequestsToReview', () => {
   });
 
   it('should return false for a pull request that not contains requests to reviewers when reviewers are expected', (): void => {
-    const when = new WhenContainsRequestsToReview(true);
+    const when = new WhenContainsRequestsToReviewCondition(true);
     const context = new LabelerContext({
       pullRequest: firstPullRequest,
       test: true,
@@ -30,7 +30,7 @@ describe('WhenContainsRequestsToReview', () => {
   });
 
   it('should return false for a pull request that contains requests to reviewers when no reviewers are expected', (): void => {
-    const when = new WhenContainsRequestsToReview(false);
+    const when = new WhenContainsRequestsToReviewCondition(false);
     const context = new LabelerContext({
       pullRequest: noReviewPullRequest,
       test: true,
@@ -42,7 +42,7 @@ describe('WhenContainsRequestsToReview', () => {
 
   it('should return true for a pull request that contains requests to reviewers when reviewers are expected and used the "nothing" option', (): void => {
     const options = new DefaultConditionOptions(null);
-    const when = new WhenContainsRequestsToReview(true, options);
+    const when = new WhenContainsRequestsToReviewCondition(true, options);
 
     options.nothing();
 

--- a/tests/Conditions/WhenFileContentConditionTest.ts
+++ b/tests/Conditions/WhenFileContentConditionTest.ts
@@ -71,4 +71,26 @@ describe('WhenFileContentCondition', () => {
     expect(result).to.be.false;
   });
 
+  it('should return false for an existing substring in the excluded file', async(): Promise<void> => {
+    const options = new WhenFileContentConditionOptions(null);
+    const when = new WhenFileContentCondition(/ValuesController/, options);
+
+    options.excludePaths(/\.cs$/);
+
+    const result = await when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return true for an existing substring when other file types are excluded', async(): Promise<void> => {
+    const options = new WhenFileContentConditionOptions(null);
+    const when = new WhenFileContentCondition(/ValuesController/, options);
+
+    options.excludePaths(/\.json$/);
+
+    const result = await when.test(context);
+
+    expect(result).to.be.true;
+  });
+
 });

--- a/tests/Conditions/WhenFileContentConditionTest.ts
+++ b/tests/Conditions/WhenFileContentConditionTest.ts
@@ -93,4 +93,50 @@ describe('WhenFileContentCondition', () => {
     expect(result).to.be.true;
   });
 
+  it('should return false for an existing substring in an unsuitable file type', async(): Promise<void> => {
+    const options = new WhenFileContentConditionOptions(null);
+    const when = new WhenFileContentCondition(/ValuesController/, options);
+
+    options.includeOnlyPaths(/\.json$/);
+
+    const result = await when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return true for an existing substring when file type match', async(): Promise<void> => {
+    const options = new WhenFileContentConditionOptions(null);
+    const when = new WhenFileContentCondition(/ValuesController/, options);
+
+    options.includeOnlyPaths(/\.cs$/);
+
+    const result = await when.test(context);
+
+    expect(result).to.be.true;
+  });
+
+  it('should return false for an existing substring in a file of a suitable type when the same type has been excluded', async(): Promise<void> => {
+    const options = new WhenFileContentConditionOptions(null);
+    const when = new WhenFileContentCondition(/ValuesController/, options);
+
+    options.excludePaths(/\.cs$/);
+    options.includeOnlyPaths(/\.cs$/);
+
+    const result = await when.test(context);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return true for an existing substring in a file of a suitable type when other types have been excluded', async(): Promise<void> => {
+    const options = new WhenFileContentConditionOptions(null);
+    const when = new WhenFileContentCondition(/ValuesController/, options);
+
+    options.excludePaths(/\.json$/);
+    options.includeOnlyPaths(/\.cs$/);
+
+    const result = await when.test(context);
+
+    expect(result).to.be.true;
+  });
+
 });

--- a/tests/Conditions/WhenFileCountConditionTest.ts
+++ b/tests/Conditions/WhenFileCountConditionTest.ts
@@ -229,4 +229,40 @@ describe('WhenFileCountCondition', () => {
     });
   });
 
+  describe('greaterThanOrEqualTo + lessThanOrEqualTo', () => {
+    it('should return true if the number of files falls within the specified range', async(): Promise<void> => {
+      const options = new WhenNumberConditionOptions(null);
+      const when = new WhenFileCountCondition(options);
+      const context = new LabelerContext({
+        pullRequest: firstPullRequest,
+        test: true,
+      });
+
+      options
+        .greaterThanOrEqualTo(2)
+        .lessThanOrEqualTo(8);
+
+      const result = await when.test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false if the number of files is outside the specified range', async(): Promise<void> => {
+      const options = new WhenNumberConditionOptions(null);
+      const when = new WhenFileCountCondition(options);
+      const context = new LabelerContext({
+        pullRequest: firstPullRequest,
+        test: true,
+      });
+
+      options
+        .greaterThanOrEqualTo(9)
+        .lessThanOrEqualTo(20);
+
+      const result = await when.test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
 });

--- a/tests/Conditions/WhenFileCountConditionTest.ts
+++ b/tests/Conditions/WhenFileCountConditionTest.ts
@@ -16,7 +16,7 @@ describe('WhenFileCountCondition', () => {
         test: true,
       });
 
-      options.equal(7);
+      options.equal(8);
 
       const result = await when.test(context);
 
@@ -95,7 +95,7 @@ describe('WhenFileCountCondition', () => {
         test: true,
       });
 
-      options.greaterThanOrEqualTo(7);
+      options.greaterThanOrEqualTo(8);
 
       const result = await when.test(context);
 
@@ -110,7 +110,7 @@ describe('WhenFileCountCondition', () => {
         test: true,
       });
 
-      options.greaterThanOrEqualTo(8);
+      options.greaterThanOrEqualTo(9);
 
       const result = await when.test(context);
 
@@ -174,7 +174,7 @@ describe('WhenFileCountCondition', () => {
         test: true,
       });
 
-      options.lessThanOrEqualTo(7);
+      options.lessThanOrEqualTo(8);
 
       const result = await when.test(context);
 

--- a/tests/Conditions/WhenFileCountConditionTest.ts
+++ b/tests/Conditions/WhenFileCountConditionTest.ts
@@ -197,4 +197,36 @@ describe('WhenFileCountCondition', () => {
     });
   });
 
+  describe('between', () => {
+    it('should return true if the number of files falls within the specified range', async(): Promise<void> => {
+      const options = new WhenNumberConditionOptions(null);
+      const when = new WhenFileCountCondition(options);
+      const context = new LabelerContext({
+        pullRequest: firstPullRequest,
+        test: true,
+      });
+
+      options.between(2, 10);
+
+      const result = await when.test(context);
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false if the number of files is outside the specified range', async(): Promise<void> => {
+      const options = new WhenNumberConditionOptions(null);
+      const when = new WhenFileCountCondition(options);
+      const context = new LabelerContext({
+        pullRequest: firstPullRequest,
+        test: true,
+      });
+
+      options.between(10, 25);
+
+      const result = await when.test(context);
+
+      expect(result).to.be.false;
+    });
+  });
+
 });

--- a/tests/Conditions/WhenFileCountConditionTest.ts
+++ b/tests/Conditions/WhenFileCountConditionTest.ts
@@ -150,7 +150,7 @@ describe('WhenFileCountCondition', () => {
     });
   });
 
-  describe('greaterThanOrEqualTo', () => {
+  describe('lessThanOrEqualTo', () => {
     it('should return true when the number of files less than the specified value', async(): Promise<void> => {
       const options = new WhenNumberConditionOptions(null);
       const when = new WhenFileCountCondition(options);

--- a/tests/Conditions/WhenFilePathConditionTest.ts
+++ b/tests/Conditions/WhenFilePathConditionTest.ts
@@ -69,9 +69,9 @@ describe('WhenFilePathCondition', () => {
 
   it('should return false for an existing file that was excluded using excludeFilePath option', async(): Promise<void> => {
     const options = new WhenFilePathConditionOptions(null);
-    const when = new WhenFilePathCondition(/.json/g, options);
+    const when = new WhenFilePathCondition(/\.json$/, options);
 
-    options.excludeFilePath(/package.json/g);
+    options.excludeFilePath(/package\.json/);
 
     const result = await when.test(context);
 

--- a/tests/Conditions/WhenMilestoneNameConditionTest.ts
+++ b/tests/Conditions/WhenMilestoneNameConditionTest.ts
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 
 import { WhenMilestoneNameCondition } from '../../src/Conditions';
 import { LabelerContext } from '../../src/LabelerContext';
-import { firstPullRequest, secondPullRequests } from '../Resources';
+import { firstPullRequest, secondPullRequest } from '../Resources';
 
 describe('WhenMilestoneNameCondition', () => {
 
   it('should return true for milestone matching name', (): void => {
     const context = new LabelerContext({
-      pullRequest: secondPullRequests,
+      pullRequest: secondPullRequest,
       test: true,
     });
     const when = new WhenMilestoneNameCondition('Version 2.0');
@@ -18,7 +18,7 @@ describe('WhenMilestoneNameCondition', () => {
 
   it('should return false for milestone non-matching name', (): void => {
     const context = new LabelerContext({
-      pullRequest: secondPullRequests,
+      pullRequest: secondPullRequest,
       test: true,
     });
     const when = new WhenMilestoneNameCondition('Version 3.0');

--- a/tests/Conditions/WhenStateConditionTest.ts
+++ b/tests/Conditions/WhenStateConditionTest.ts
@@ -1,15 +1,15 @@
 import { expect } from 'chai';
 
 import { DefaultConditionOptions } from '../../src/ConditionOptions';
-import { WhenState } from '../../src/Conditions';
+import { WhenStateCondition } from '../../src/Conditions';
 import { LabelerContext } from '../../src/LabelerContext';
 import { firstPullRequest } from '../Resources';
 import { closedPullRequest, mergedPullRequest } from '../Resources/PullRequests';
 
-describe('WhenState', () => {
+describe('WhenStateCondition', () => {
 
   it('should return true for opened a pull request', (): void => {
-    const when = new WhenState('open');
+    const when = new WhenStateCondition('open');
     const context = new LabelerContext({
       pullRequest: firstPullRequest,
       test: true,
@@ -20,7 +20,7 @@ describe('WhenState', () => {
 
   it('should return false for opened a pull request with the "nothing" options', (): void => {
     const options = new DefaultConditionOptions(null);
-    const when = new WhenState('open', options);
+    const when = new WhenStateCondition('open', options);
     const context = new LabelerContext({
       pullRequest: firstPullRequest,
       test: true,
@@ -32,7 +32,7 @@ describe('WhenState', () => {
   });
 
   it('should return true for closed a pull request', (): void => {
-    const when = new WhenState('closed');
+    const when = new WhenStateCondition('closed');
     const context = new LabelerContext({
       pullRequest: closedPullRequest,
       test: true,
@@ -43,7 +43,7 @@ describe('WhenState', () => {
 
   it('should return false for closed a pull request with the "nothing" options', (): void => {
     const options = new DefaultConditionOptions(null);
-    const when = new WhenState('closed', options);
+    const when = new WhenStateCondition('closed', options);
     const context = new LabelerContext({
       pullRequest: closedPullRequest,
       test: true,
@@ -55,7 +55,7 @@ describe('WhenState', () => {
   });
 
   it('should return false for merged a pull request', (): void => {
-    const when = new WhenState('closed');
+    const when = new WhenStateCondition('closed');
     const context = new LabelerContext({
       pullRequest: mergedPullRequest,
       test: true,
@@ -66,7 +66,7 @@ describe('WhenState', () => {
 
   it('should return true for merged a pull request with the "nothing" options', (): void => {
     const options = new DefaultConditionOptions(null);
-    const when = new WhenState('closed', options);
+    const when = new WhenStateCondition('closed', options);
     const context = new LabelerContext({
       pullRequest: mergedPullRequest,
       test: true,
@@ -78,7 +78,7 @@ describe('WhenState', () => {
   });
 
   it('should return true for merged a pull request', (): void => {
-    const when = new WhenState('merged');
+    const when = new WhenStateCondition('merged');
     const context = new LabelerContext({
       pullRequest: mergedPullRequest,
       test: true,
@@ -89,7 +89,7 @@ describe('WhenState', () => {
 
   it('should return false for merged a pull request with the "nothing" options', (): void => {
     const options = new DefaultConditionOptions(null);
-    const when = new WhenState('merged', options);
+    const when = new WhenStateCondition('merged', options);
     const context = new LabelerContext({
       pullRequest: mergedPullRequest,
       test: true,

--- a/tests/Resources/PullRequests/ApprovedAndCommentedPullRequest.ts
+++ b/tests/Resources/PullRequests/ApprovedAndCommentedPullRequest.ts
@@ -28,6 +28,9 @@ export const approvedAndCommentedPullRequest: PullRequest = {
   commits: emptyListOfCacheableAction<Commit>(),
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
+  requestedReviewers: [
+    msSoftLoUser,
+  ],
   reviews: new CacheableAction(() => Promise.resolve<Array<Review>>([
     {
       author: msSoftLoUser,

--- a/tests/Resources/PullRequests/ApprovedAndCommentedPullRequest2.ts
+++ b/tests/Resources/PullRequests/ApprovedAndCommentedPullRequest2.ts
@@ -28,6 +28,9 @@ export const approvedAndCommentedPullRequest2: PullRequest = {
   commits: emptyListOfCacheableAction<Commit>(),
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
+  requestedReviewers: [
+    loftSomsUser,
+  ],
   reviews: new CacheableAction(() => Promise.resolve<Array<Review>>([
     {
       author: msSoftLoUser,

--- a/tests/Resources/PullRequests/ApprovedSimplePullRequest.ts
+++ b/tests/Resources/PullRequests/ApprovedSimplePullRequest.ts
@@ -28,6 +28,9 @@ export const approvedSimplePullRequest: PullRequest = {
   commits: emptyListOfCacheableAction<Commit>(),
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
+  requestedReviewers: [
+    msSoftLoUser,
+  ],
   reviews: new CacheableAction(() => Promise.resolve<Array<Review>>([
     {
       author: msSoftLoUser,

--- a/tests/Resources/PullRequests/ChangesRequestedSimplePullRequest.ts
+++ b/tests/Resources/PullRequests/ChangesRequestedSimplePullRequest.ts
@@ -28,6 +28,7 @@ export const changesRequestedSimplePullRequest: PullRequest = {
   commits: emptyListOfCacheableAction<Commit>(),
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
+  requestedReviewers: [],
   reviews: new CacheableAction(() => Promise.resolve<Array<Review>>([
     {
       author: msSoftLoUser,

--- a/tests/Resources/PullRequests/ClosedPullRequest.ts
+++ b/tests/Resources/PullRequests/ClosedPullRequest.ts
@@ -28,4 +28,5 @@ export const closedPullRequest: PullRequest = {
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
   reviews: emptyListOfCacheableAction<Review>(),
+  requestedReviewers: [],
 };

--- a/tests/Resources/PullRequests/FirstPullRequest.ts
+++ b/tests/Resources/PullRequests/FirstPullRequest.ts
@@ -212,6 +212,7 @@ export const firstPullRequest: PullRequest = {
   state: 'open',
   title: 'Awesome pull request',
   createdDate: new Date(2020, 9, 18, 12, 51, 0),
+  requestedReviewers: [],
   reviews: new CacheableAction(() => Promise.resolve<Array<Review>>([
     {
       author: msSoftLoUser,

--- a/tests/Resources/PullRequests/FirstPullRequest.ts
+++ b/tests/Resources/PullRequests/FirstPullRequest.ts
@@ -234,7 +234,7 @@ export const firstPullRequest: PullRequest = {
     mergeable: true,
     mergeableState: 'clean',
     rebaseable: true,
-    changedFiles: 7,
+    changedFiles: 8,
     comments: 4,
     commits: 3,
   })),

--- a/tests/Resources/PullRequests/MergedPullRequest.ts
+++ b/tests/Resources/PullRequests/MergedPullRequest.ts
@@ -29,4 +29,5 @@ export const mergedPullRequest: PullRequest = {
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
   reviews: emptyListOfCacheableAction<Review>(),
+  requestedReviewers: [],
 };

--- a/tests/Resources/PullRequests/NoReviewPullRequest.ts
+++ b/tests/Resources/PullRequests/NoReviewPullRequest.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../src/ApiProviders';
 import { emptyCacheableAction, emptyListOfCacheableAction } from '../../Helpers';
 import { issue1Branch, mainBranch } from '../Branches';
-import { msSoftLoUser } from '../Users';
+import { flossMotUser, loftSomsUser, msSoftLoUser } from '../Users';
 
 export const noReviewPullRequest: PullRequest = {
   author: msSoftLoUser,
@@ -28,4 +28,8 @@ export const noReviewPullRequest: PullRequest = {
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
   reviews: emptyListOfCacheableAction<Review>(),
+  requestedReviewers: [
+    flossMotUser,
+    loftSomsUser,
+  ],
 };

--- a/tests/Resources/PullRequests/PartialApprovedAndCommentedPullRequest.ts
+++ b/tests/Resources/PullRequests/PartialApprovedAndCommentedPullRequest.ts
@@ -34,6 +34,7 @@ export const partialApprovedAndCommentedPullRequest: PullRequest = {
   commits: emptyListOfCacheableAction<Commit>(),
   files: emptyListOfCacheableAction<File>(),
   statusInfo: emptyCacheableAction<PullRequestStatus>(),
+  requestedReviewers: [],
   reviews: new CacheableAction(() => Promise.resolve<Array<Review>>([
     {
       author: msSoftLoUser,

--- a/tests/Resources/PullRequests/SecondPullRequest.ts
+++ b/tests/Resources/PullRequests/SecondPullRequest.ts
@@ -10,7 +10,7 @@ import { CacheableAction } from '../../../src/CacheableAction';
 import { issue2Branch, mainBranch } from '../Branches';
 import { flossTomUser, loftMossUser, msSoftLoUser } from '../Users';
 
-export const secondPullRequests: PullRequest = {
+export const secondPullRequest: PullRequest = {
   author: loftMossUser,
   code: 2,
   comments: new CacheableAction(() => Promise.resolve<Array<Comment>>([])),

--- a/tests/Resources/PullRequests/SecondPullRequest.ts
+++ b/tests/Resources/PullRequests/SecondPullRequest.ts
@@ -46,6 +46,7 @@ export const secondPullRequests: PullRequest = {
   state: 'open',
   title: 'Readme fixes',
   createdDate: new Date(2020, 9, 24, 0, 30, 0),
+  requestedReviewers: [],
   reviews: new CacheableAction(() => Promise.resolve<Array<Review>>([
     {
       author: msSoftLoUser,

--- a/tests/Resources/PullRequests/index.ts
+++ b/tests/Resources/PullRequests/index.ts
@@ -7,4 +7,4 @@ export { firstPullRequest } from './FirstPullRequest';
 export { mergedPullRequest } from './MergedPullRequest';
 export { noReviewPullRequest } from './NoReviewPullRequest';
 export { partialApprovedAndCommentedPullRequest } from './PartialApprovedAndCommentedPullRequest';
-export { secondPullRequests } from './SecondPullRequest';
+export { secondPullRequest } from './SecondPullRequest';

--- a/tests/Resources/index.ts
+++ b/tests/Resources/index.ts
@@ -19,5 +19,5 @@ export {
   firstPullRequest,
   noReviewPullRequest,
   partialApprovedAndCommentedPullRequest,
-  secondPullRequests,
+  secondPullRequest,
 } from './PullRequests';


### PR DESCRIPTION
* Added `excludePaths` and `includeOnlyPaths` options for `whenFileContent` condition.
* Added `between` option for `whenFileCount`, `whenCommentCount`, and `whenCommitCount` conditions.
* Added `whenHasRequestsToReview` and `whenHasNoRequestsToReview` conditions.
* Fixed bugs with missed options in `whenHasConflicts`, `whenHasNoConflicts`, `whenOpen`, `whenClosed`, and `whenWasMerged` conditions.